### PR TITLE
fix geth build path inside container(sh)

### DIFF
--- a/Docker/readme.md
+++ b/Docker/readme.md
@@ -16,7 +16,7 @@ This will pull the latest stable release of Ethereum Classic golang full node.
 
 ``docker run -it ethereumclassic/etc-geth sh``
 
-``./go-ethereum/build/bin/geth``
+``./bin/geth``
 
 For edit access please contact the #development channel in slack
 

--- a/Docker/readme.md
+++ b/Docker/readme.md
@@ -28,7 +28,7 @@ This will pull the latest development release of Ethereum Classic software.
 
 ``docker run -it ethereumclassic/etc-geth-dev sh``
 
-``./go-ethereum/build/bin/geth``
+``./bin/geth``
 
 For edit access please contact the #development channel in slack
 


### PR DESCRIPTION
Fixing README to go to the correct path of the `geth` exec inside the container.